### PR TITLE
Potential fix for code scanning alert no. 35: Code injection

### DIFF
--- a/core/appHandler.js
+++ b/core/appHandler.js
@@ -216,16 +216,20 @@ module.exports.listUsersAPI = function (req, res) {
 module.exports.bulkProductsLegacy = function (req,res){
 	// TODO: Deprecate this soon
 	if(req.files.products){
-		var products = serialize.unserialize(req.files.products.data.toString('utf8'))
-		products.forEach( function (product) {
-			var newProduct = new db.Product()
-			newProduct.name = product.name
-			newProduct.code = product.code
-			newProduct.tags = product.tags
-			newProduct.description = product.description
-			newProduct.save()
-		})
-		res.redirect('/app/products')
+		try {
+			var products = JSON.parse(req.files.products.data.toString('utf8'));
+			products.forEach( function (product) {
+				var newProduct = new db.Product()
+				newProduct.name = product.name
+				newProduct.code = product.code
+				newProduct.tags = product.tags
+				newProduct.description = product.description
+				newProduct.save()
+			})
+			res.redirect('/app/products')
+		} catch (e) {
+			res.render('app/bulkproducts',{messages:{danger:'Invalid file format'},legacy:true})
+		}
 	}else{
 		res.render('app/bulkproducts',{messages:{danger:'Invalid file'},legacy:true})
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/FelipePLima/dvna/security/code-scanning/35](https://github.com/FelipePLima/dvna/security/code-scanning/35)

To fix the problem, we need to avoid directly using `serialize.unserialize` on user-provided input. Instead, we should validate and sanitize the input before processing it. One way to achieve this is by using a safer serialization library or by implementing custom validation logic to ensure the input is safe.

In this case, we can use the `JSON.parse` method instead of `serialize.unserialize`, as it is safer and does not execute arbitrary code. We will also add a try-catch block to handle any parsing errors gracefully.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
