### PR TITLE
Potential fix for code scanning alert no. 30: XML internal entity expansion

### DIFF
--- a/core/appHandler.js
+++ b/core/appHandler.js
@@ -2,7 +2,7 @@ var db = require('../models')
 var bCrypt = require('bcrypt')
 const exec = require('child_process').exec;
 var mathjs = require('mathjs')
-var libxmljs = require("libxmljs");
+var sax = require("sax");
 var serialize = require("node-serialize")
 const Op = db.Sequelize.Op
 
@@ -237,17 +237,46 @@ module.exports.bulkProductsLegacy = function (req,res){
 
 module.exports.bulkProducts =  function(req, res) {
 	if (req.files.products && req.files.products.mimetype=='text/xml'){
-		var products = libxmljs.parseXmlString(req.files.products.data.toString('utf8'), {noent:true,noblanks:true})
-		products.root().childNodes().forEach( product => {
-			var newProduct = new db.Product()
-			newProduct.name = product.childNodes()[0].text()
-			newProduct.code = product.childNodes()[1].text()
-			newProduct.tags = product.childNodes()[2].text()
-			newProduct.description = product.childNodes()[3].text()
-			newProduct.save()
-		})
-		res.redirect('/app/products')
+		var parser = sax.parser(true);
+		var products = [];
+		var currentProduct = null;
+		
+		parser.onopentag = function (node) {
+			if (node.name === "product") {
+				currentProduct = {};
+			} else if (currentProduct) {
+				currentProduct[node.name] = "";
+			}
+		};
+		
+		parser.ontext = function (text) {
+			if (currentProduct) {
+				var keys = Object.keys(currentProduct);
+				if (keys.length > 0) {
+					currentProduct[keys[keys.length - 1]] += text;
+				}
+			}
+		};
+		
+		parser.onclosetag = function (name) {
+			if (name === "product" && currentProduct) {
+				products.push(currentProduct);
+				currentProduct = null;
+			}
+		};
+		
+		parser.write(req.files.products.data.toString('utf8')).close();
+		
+		products.forEach(product => {
+			var newProduct = new db.Product();
+			newProduct.name = product.name;
+			newProduct.code = product.code;
+			newProduct.tags = product.tags;
+			newProduct.description = product.description;
+			newProduct.save();
+		});
+		res.redirect('/app/products');
 	}else{
-		res.render('app/bulkproducts',{messages:{danger:'Invalid file'},legacy:false})
+		res.render('app/bulkproducts',{messages:{danger:'Invalid file'},legacy:false});
 	}
 }


### PR DESCRIPTION
Potential fix for [https://github.com/FelipePLima/dvna/security/code-scanning/30](https://github.com/FelipePLima/dvna/security/code-scanning/30)

To fix the problem, we need to disable entity expansion when parsing the XML data. This can be achieved by using a different XML parsing library that does not allow entity expansion by default or by configuring the current library to disable entity expansion.

The best way to fix this issue without changing existing functionality is to switch from `libxmljs` to the `sax` library, which only expands standard entities such as `&amp;`. This will prevent the risk of XML bomb attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
